### PR TITLE
Update screenshot for rubydoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 CHANGELOG
 ---------
-- **2016-11-03**: 0.3.1
+- **2016-11-03**: 0.3.4-0.3.1
   - Add screenshot image to `gemspec`
-- **2016-10-24**: 0.3.0
   - Add identicon support
 - **2016-10-23**: 0.2.0
   - Add avatar customization options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 CHANGELOG
 ---------
+- **2016-11-03**: 0.3.1
+  - Add screenshot image to `gemspec`
 - **2016-10-24**: 0.3.0
   - Add identicon support
 - **2016-10-23**: 0.2.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library will build [RingCentral](https://ringcentral.com) avatars using Gma
 
 By default, the images will look like the following in the RingCentral softphone:
 
-![](docs/images/ringcentral-avatars-softphone.png)
+![](https://raw.githubusercontent.com/ringcentral-ruby/ringcentral-avatars-ruby/master/docs/images/ringcentral-avatars-softphone.png)
 
 This library uses [Avatarly](https://github.com/lucek/avatarly) to generate the avatars and can pass through any avatar option for customization purposes.
 

--- a/lib/ringcentral-avatars.rb
+++ b/lib/ringcentral-avatars.rb
@@ -2,7 +2,7 @@ require 'ringcentral-avatars/creator'
 
 module RingCentral
   module Avatars
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
 
     class << self
       def new(client, opts = {})

--- a/lib/ringcentral-avatars.rb
+++ b/lib/ringcentral-avatars.rb
@@ -2,7 +2,7 @@ require 'ringcentral-avatars/creator'
 
 module RingCentral
   module Avatars
-    VERSION = '0.3.1'
+    VERSION = '0.3.4'
 
     class << self
       def new(client, opts = {})

--- a/ringcentral-avatars.gemspec
+++ b/ringcentral-avatars.gemspec
@@ -6,7 +6,7 @@ version = $1
 Gem::Specification.new do |s|
   s.name        = lib
   s.version     = version
-  s.date        = '2016-10-24'
+  s.date        = '2016-11-03'
   s.summary     = 'RingCentral library for auto-generating Gmail style avatars'
   s.description = 'Create RingCentral avatars using Gmail-style avatars'
   s.authors     = ['John Wang']


### PR DESCRIPTION
Update to use fully qualified URL for `README.md` screenshot so that image appears in RubyDoc.info.